### PR TITLE
Fix for issue #7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <description>Coreos ETCD key-value store web viewer</description>
 
   <properties>
-    <wicket.version>6.19.0</wicket.version>
+    <wicket.version>6.24.0</wicket.version>
     <cxf.version>3.1.0</cxf.version>
     <jackson.version>2.5.3</jackson.version>
     <jetty.version>9.2.10.v20150310</jetty.version>


### PR DESCRIPTION
Previous version of Wicket had issues handling URLs with colons, which broke viewing etcd keys with colons in their names.
